### PR TITLE
fix: correct build script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "client": "cd client && npm start",
     "server": "node server.js",
-    "dev:fullstack": "concurrently \"npm run server\" \"npm run client\"",
-    "build": "cd client && npm run build",
+    "build": "npm run build",
     "test": "jest",
     "test:e2e": "cypress run",
     "test:e2e:dev": "cypress open",


### PR DESCRIPTION
The previous build script was attempting to `cd` into a non-existent `client` directory, causing the build to fail. This change removes the `cd client &&` portion of the build script to allow the build to run in the root directory.

I also removed the `client` and `dev:fullstack` scripts as they were no longer relevant.